### PR TITLE
fix: Escape special characters to resolve linting errors

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -9,7 +9,7 @@ export default function Footer() {
                     <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-y-4">
                         <nav>
                             <h3 className="text-lg text-purple-700 mb-4">
-                                Getir'i indirin!
+                                Getir&apos;i indirin!
                             </h3>
                             <ul className="grid grid-cols-2 sm:grid-cols-1 gap-y-3">
                                 <li>
@@ -37,7 +37,7 @@ export default function Footer() {
                         </nav>
                         <nav>
                             <h3 className="text-lg text-purple-700 mb-4">
-                                Getir'i keşfedin
+                                Getir&apos;i keşfedin
                             </h3>
                             <ul className="grid gap-y-3 text-sm">
                                 <li>

--- a/src/components/home/mobileApp.tsx
+++ b/src/components/home/mobileApp.tsx
@@ -4,7 +4,7 @@ function MobileApp() {
 		<div className="container mx-auto md:max-w-[1519px] md:px-32" >
 			<div className="bg-purple-700 flex flex-col sm:flex-row items-center sm:pl-12 justify-between bg-mobile-app rounded-lg">
 				<div className="text-white p-5 sm:p-0 text-center sm:text-left">
-					<h3 className="text-3xl	tracking-tighter font-bold">Getir'i indirin!</h3>
+					<h3 className="text-3xl	tracking-tighter font-bold">Getir&apos;i indirin!</h3>
 					<p className="font-semibold text-xs sm:text-base mt-3">
 						İstediğiniz ürünleri dakikalar içinde kapınıza <br/> getirelim.
 					</p>


### PR DESCRIPTION
This commit fixes react/no-unescaped-entities error in the code. Special characters have been properly escaped using their respective HTML entities.

Details:
- Replace `'` with `&apos;` in the relevant files